### PR TITLE
Fix close channel

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,8 +1,11 @@
 name: Build & Release GC valtrack scraper
 
 on:
-    pull_request:
-      types: [ closed ]
+    # pull_request:
+    #   types: [ closed ]
+    push:
+      branches:
+        - master
 
 concurrency:
   group: gc-valtrack-${{ github.ref }}
@@ -11,13 +14,9 @@ concurrency:
 jobs:
   build:
     
-    if: github.event.pull_request.merged == true
+    # if: github.event.pull_request.merged == true
 
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       
@@ -35,6 +34,9 @@ jobs:
         id: commit
         uses: prompt/actions-commit-hash@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3.3.0
         with:
@@ -44,11 +46,12 @@ jobs:
 
       - name: Push Latest
         run: |
-          docker build . --tag ghcr.io/${{ steps.org_name.outputs.org_name }}/valtrack:latest
-          docker push ghcr.io/${{ steps.org_name.outputs.org_name }}/valtrack:latest
-
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/${{ steps.org_name.outputs.org_name }}/valtrack:latest \
+            --push .
+    
       - name: Push Versioned
         run: |
-          docker build . --tag ghcr.io/${{ steps.org_name.outputs.org_name }}/valtrack:${{ steps.commit.outputs.short }}
-          docker push ghcr.io/${{ steps.org_name.outputs.org_name }}/valtrack:${{ steps.commit.outputs.short }}
-            
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/${{ steps.org_name.outputs.org_name }}/valtrack:${{ steps.commit.outputs.short }} \
+            --push .

--- a/consumer/db.go
+++ b/consumer/db.go
@@ -9,6 +9,7 @@ import (
     "os"
     "strconv"
     "strings"
+    "time"
 
     "github.com/ipinfo/go/v2/ipinfo"
     ma "github.com/multiformats/go-multiaddr"
@@ -170,136 +171,167 @@ func insertIPMetadata(tx *sql.Tx, ipEvent *types.IPMetadataEvent) error {
     return err
 }
 
-func (c *Consumer) runValidatorMetadataEventHandler(token string) error {
+func (c *Consumer) runValidatorMetadataEventHandler(token string) {
     client := ipinfo.NewClient(nil, nil, token)
     batchSize := 0
-    tx, err := c.db.Begin()
-    if err != nil {
-        return err
-    }
+    var tx *sql.Tx
+    var err error
 
     for {
-        event := <-c.validatorMetadataChan
-        c.log.Trace().Any("event", event).Msg("Received validator event")
-
-        maddr, err := ma.NewMultiaddr(event.Multiaddr)
-        if err != nil {
-            c.log.Error().Err(err).Msg("Invalid multiaddr")
-            continue
-        }
-
-        ip, err := maddr.ValueForProtocol(ma.P_IP4)
-        if err != nil {
-            ip, err = maddr.ValueForProtocol(ma.P_IP6)
-            if err != nil {
-                c.log.Error().Err(err).Msg("Invalid IP in multiaddr")
-                continue
+        select {
+        case <-c.done:
+            if tx != nil {
+                tx.Rollback()
             }
-        }
+            return
+        default:
+            func() {
+                defer func() {
+                    if r := recover(); r != nil {
+                        c.log.Error().Interface("recover", r).Msg("Recovered from panic in validator metadata handler")
+                        if tx != nil {
+                            tx.Rollback()
+                        }
+                    }
+                }()
 
-        portStr, err := maddr.ValueForProtocol(ma.P_TCP)
-        if err != nil {
-            c.log.Error().Err(err).Msg("Invalid port in multiaddr")
-            continue
-        }
-
-        port, err := strconv.Atoi(portStr)
-        if err != nil {
-            c.log.Error().Err(err).Msg("Invalid port number")
-            continue
-        }
-
-        longLived := indexesFromBitfield(event.MetaData.Attnets)
-        shortLived := extractShortLivedSubnets(event.SubscribedSubnets, longLived)
-        currValidatorCount := len(shortLived)
-
-        var prevTotalObservations int
-        err = c.db.QueryRow("SELECT total_observations FROM validator_tracker WHERE peer_id = ?", event.ID).Scan(&prevTotalObservations)
-
-        if err == sql.ErrNoRows {
-            _, err = tx.Exec(insertTrackerQuery, event.ID, event.ENR, event.Multiaddr, ip, port, event.Timestamp, event.Epoch, event.ClientVersion, 1)
-            if err != nil {
-                c.log.Error().Err(err).Msg("Error inserting row")
-            }
-
-            _, err = tx.Exec(insertValidatorCountsQuery, event.ID, currValidatorCount)
-            if err != nil {
-                c.log.Error().Err(err).Msg("Error inserting validator count")
-            }
-
-            batchSize++
-
-            if err := c.db.QueryRow(selectIpMetadataQuery, ip).Scan(); err == sql.ErrNoRows {
-                c.log.Info().Str("ip", ip).Msg("Unknown IP, fetching IP info...")
-                go func(ip string) {
-                    ipInfo, err := client.GetIPInfo(net.ParseIP(ip))
+                if tx == nil {
+                    tx, err = c.db.Begin()
                     if err != nil {
-                        c.log.Error().Err(err).Msg("Error fetching IP info")
+                        c.log.Error().Err(err).Msg("Failed to begin transaction")
+                        time.Sleep(time.Second)
                         return
                     }
+                }
 
-                    asn := ""
-                    asnOrg := ""
-                    asnType := ""
-                    if ipInfo.ASN != nil {
-                        asn = ipInfo.ASN.ASN
-                        asnOrg = ipInfo.ASN.Name
-                        asnType = ipInfo.ASN.Type
-                    }
+                event, ok := c.validatorMetadataChan.Receive()
+                if !ok {
+                    c.log.Warn().Msg("Validator metadata channel closed unexpectedly, recreating")
+                    c.validatorMetadataChan = NewSafeChannel()
+                    return
+                }
 
-                    parts := strings.Split(ipInfo.Location, ",")
-                    lat, _ := strconv.ParseFloat(parts[0], 64)
-                    long, _ := strconv.ParseFloat(parts[1], 64)
+                c.log.Trace().Any("event", event).Msg("Received validator event")
 
-                    ipMeta := types.IPMetadataEvent{
-                        IP:       ipInfo.IP.String(),
-                        Hostname: ipInfo.Hostname,
-                        City:     ipInfo.City,
-                        Region:   ipInfo.Region,
-                        Country:  ipInfo.Country,
-                        Latitude: lat,
-                        Longitude: long,
-                        PostalCode: ipInfo.Postal,
-                        ASN:      asn,
-                        ASNOrganization: asnOrg,
-                        ASNType:  asnType,
-                    }
+                maddr, err := ma.NewMultiaddr(event.Multiaddr)
+                if err != nil {
+                    c.log.Error().Err(err).Msg("Invalid multiaddr")
+                    return
+                }
 
-                    if err := insertIPMetadata(tx, &ipMeta); err != nil {
-                        c.log.Error().Err(err).Msg("Error inserting IP metadata")
+                ip, err := maddr.ValueForProtocol(ma.P_IP4)
+                if err != nil {
+                    ip, err = maddr.ValueForProtocol(ma.P_IP6)
+                    if err != nil {
+                        c.log.Error().Err(err).Msg("Invalid IP in multiaddr")
                         return
+                    }
+                }
+
+                portStr, err := maddr.ValueForProtocol(ma.P_TCP)
+                if err != nil {
+                    c.log.Error().Err(err).Msg("Invalid port in multiaddr")
+                    return
+                }
+
+                port, err := strconv.Atoi(portStr)
+                if err != nil {
+                    c.log.Error().Err(err).Msg("Invalid port number")
+                    return
+                }
+
+                longLived := indexesFromBitfield(event.MetaData.Attnets)
+                shortLived := extractShortLivedSubnets(event.SubscribedSubnets, longLived)
+                currValidatorCount := len(shortLived)
+
+                var prevTotalObservations int
+                err = c.db.QueryRow("SELECT total_observations FROM validator_tracker WHERE peer_id = ?", event.ID).Scan(&prevTotalObservations)
+
+                if err == sql.ErrNoRows {
+                    _, err = tx.Exec(insertTrackerQuery, event.ID, event.ENR, event.Multiaddr, ip, port, event.Timestamp, event.Epoch, event.ClientVersion, 1)
+                    if err != nil {
+                        c.log.Error().Err(err).Msg("Error inserting row")
+                    }
+
+                    _, err = tx.Exec(insertValidatorCountsQuery, event.ID, currValidatorCount)
+                    if err != nil {
+                        c.log.Error().Err(err).Msg("Error inserting validator count")
                     }
 
                     batchSize++
-                    c.ipMetadataChan <- &ipMeta
-                }(ip)
-            }
-            c.log.Trace().Str("peer_id", event.ID).Msg("Inserted new row")
-        } else if err != nil {
-            c.log.Error().Err(err).Msg("Error querying validator_tracker database")
-        } else {
-            _, err = tx.Exec(updateTrackerQuery, event.ENR, event.Multiaddr, ip, port, event.Timestamp, event.Epoch, event.ClientVersion, event.ID)
-            if err != nil {
-                c.log.Error().Err(err).Msg("Error updating row")
-            }
 
-            _, err = tx.Exec(insertValidatorCountsQuery, event.ID, currValidatorCount)
-            if err != nil {
-                c.log.Error().Err(err).Msg("Error inserting validator count")
-            }
+                    if err := c.db.QueryRow(selectIpMetadataQuery, ip).Scan(); err == sql.ErrNoRows {
+                        c.log.Info().Str("ip", ip).Msg("Unknown IP, fetching IP info...")
+                        go func(ip string) {
+                            ipInfo, err := client.GetIPInfo(net.ParseIP(ip))
+                            if err != nil {
+                                c.log.Error().Err(err).Msg("Error fetching IP info")
+                                return
+                            }
 
-            batchSize++
-            c.log.Trace().Str("peer_id", event.ID).Msg("Updated row")
-        }
+                            asn := ""
+                            asnOrg := ""
+                            asnType := ""
+                            if ipInfo.ASN != nil {
+                                asn = ipInfo.ASN.ASN
+                                asnOrg = ipInfo.ASN.Name
+                                asnType = ipInfo.ASN.Type
+                            }
 
-        if batchSize >= 32 {
-            tx.Commit()
-            tx, err = c.db.Begin()
-            if err != nil {
-                return err
-            }
+                            parts := strings.Split(ipInfo.Location, ",")
+                            lat, _ := strconv.ParseFloat(parts[0], 64)
+                            long, _ := strconv.ParseFloat(parts[1], 64)
 
-            batchSize = 0
+                            ipMeta := types.IPMetadataEvent{
+                                IP:               ipInfo.IP.String(),
+                                Hostname:         ipInfo.Hostname,
+                                City:             ipInfo.City,
+                                Region:           ipInfo.Region,
+                                Country:          ipInfo.Country,
+                                Latitude:         lat,
+                                Longitude:        long,
+                                PostalCode:       ipInfo.Postal,
+                                ASN:              asn,
+                                ASNOrganization:  asnOrg,
+                                ASNType:          asnType,
+                            }
+
+                            if err := insertIPMetadata(tx, &ipMeta); err != nil {
+                                c.log.Error().Err(err).Msg("Error inserting IP metadata")
+                                return
+                            }
+
+                            batchSize++
+                            c.ipMetadataChan <- &ipMeta
+                        }(ip)
+                    }
+                    c.log.Trace().Str("peer_id", event.ID).Msg("Inserted new row")
+                } else if err != nil {
+                    c.log.Error().Err(err).Msg("Error querying validator_tracker database")
+                } else {
+                    _, err = tx.Exec(updateTrackerQuery, event.ENR, event.Multiaddr, ip, port, event.Timestamp, event.Epoch, event.ClientVersion, event.ID)
+                    if err != nil {
+                        c.log.Error().Err(err).Msg("Error updating row")
+                    }
+
+                    _, err = tx.Exec(insertValidatorCountsQuery, event.ID, currValidatorCount)
+                    if err != nil {
+                        c.log.Error().Err(err).Msg("Error inserting validator count")
+                    }
+
+                    batchSize++
+                    c.log.Trace().Str("peer_id", event.ID).Msg("Updated row")
+                }
+
+                if batchSize >= 32 {
+                    if err := tx.Commit(); err != nil {
+                        c.log.Error().Err(err).Msg("Failed to commit transaction")
+                        tx.Rollback()
+                    }
+                    tx = nil
+                    batchSize = 0
+                }
+            }()
         }
     }
 }


### PR DESCRIPTION
# Summary of Changes to Resolve "send on closed channel" Issue

## Problem
The initial issue was a panic occurring due to an attempt to send on a closed channel:
```sh
goroutine 169362410 [running]:
github.com/chainbound/valtrack/consumer.(*Consumer).runValidatorMetadataEventHandler.func1({0xc00189f6a2, 0xe})
/app/consumer/db.go:274 +0x41b
created by github.com/chainbound/valtrack/consumer.(*Consumer).runValidatorMetadataEventHandler in goroutine 210
/app/consumer/db.go:234 +0xf15
```

## Solution Overview
To address this issue and improve the overall robustness of the system, we implemented a `SafeChannel` and made several related changes.

## Detailed Changes

### Introduced SafeChannel

Created a new struct `SafeChannel` to wrap the channel operations.
Implemented methods Send, Receive, and Close for safe operations.

```go
type SafeChannel struct {
    ch   chan *types.MetadataReceivedEvent
    mu   sync.RWMutex
    done chan struct{}
}
```
### Updated Consumer struct

Changed validatorMetadataChan from a raw channel to a *SafeChannel.
Added wg (WaitGroup) and done channel for graceful shutdown.
```go
type Consumer struct {
    // ...
    validatorMetadataChan *SafeChannel
    wg   sync.WaitGroup
    done chan struct{}
}
```

### Modified NewConsumer function

Initialize the new validatorMetadataChan as a SafeChannel.
Initialize the done channel.

### Updated Start method

Use WaitGroup for goroutines.
Start the health check routine.

```go
func (c *Consumer) Start(name string) error {
    // ...
    c.wg.Add(1)
    go func() {
        defer c.wg.Done()
        c.runValidatorMetadataEventHandler(c.ipInfoToken)
    }()
    go c.startHealthCheck()
    // ...
}
```

### Implemented Shutdown method

Close the done channel to signal shutdown.
Close the validatorMetadataChan.
Wait for all goroutines to finish using WaitGroup.

```go
func (c *Consumer) Shutdown() {
    close(c.done)
    c.validatorMetadataChan.Close()
    c.wg.Wait()
    // ...
}
```

### Modified runValidatorMetadataEventHandler

Use SafeChannel's Receive method instead of direct channel receive.
Implement graceful shutdown using the done channel.
Add panic recovery.

```go
func (c *Consumer) runValidatorMetadataEventHandler(token string) {
    // ...
    for {
        select {
        case <-c.done:
            // Graceful shutdown
            return
        default:
            func() {
                defer func() {
                    if r := recover(); r != nil {
                        // Handle panic
                    }
                }()
                event, ok := c.validatorMetadataChan.Receive()
                // ...
            }()
        }
    }
}
```
### Updated handleMetadataEvent

Use SafeChannel's Send method instead of direct channel send.
```go
func (c *Consumer) handleMetadataEvent(event types.MetadataReceivedEvent) {
    // ...
    c.validatorMetadataChan.Send(&event)
    // ...
}
```
### Implemented Health Check

Added methods to check and restart the validator metadata handler if needed.
```go
func (c *Consumer) startHealthCheck() {
    // Periodically check health and restart if necessary
}
```

## How These Changes Address the Issue

- Prevent Sending on Closed Channel: The SafeChannel structure ensures that even if the underlying channel is closed, we can recreate it safely without causing a panic.
- Graceful Shutdown: The done channel and WaitGroup allow for coordinated shutdown of all goroutines, preventing scenarios where we might try to send on a channel that's being closed.
- Error Recovery: Panic recovery in key goroutines prevents the entire application from crashing due to unexpected errors.
- Health Monitoring: The health check mechanism can detect and restart handlers that have become unresponsive, improving overall system resilience.
- Coordinated Operations: Using mutex in SafeChannel ensures thread-safe operations on the channel, preventing race conditions that could lead to inconsistent states.
